### PR TITLE
Split up dice rolling and moving

### DIFF
--- a/Assets/Scripts/Counter/CounterController.cs
+++ b/Assets/Scripts/Counter/CounterController.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using UnityEngine;
 
 
@@ -35,7 +34,7 @@ public class CounterController : MonoBehaviour
     /// </summary>
     public void PlayTurn()
     {
-        rollData roll = RollDice();
+        RollData roll = RollDice();
         MoveCounter(roll.dice1, roll.dice2);
         if (roll.doubleRoll)
         {
@@ -73,14 +72,14 @@ public class CounterController : MonoBehaviour
     /// Rolls two dice, and returns them, along with whether the dice rolls are the same.
     /// </summary>
     /// <returns> a record containing the two dice rolls as integers, as well as a boolean to denote whether the dice rolls were the same. </returns>
-    public rollData RollDice()
+    public RollData RollDice()
     {
         // Gets the first dice's value
         int dice1 = Random.Range(1, 7);
         // Gets the second dice's value
         int dice2 = Random.Range(1, 7);
         
-        return new rollData(dice1, dice2, dice1 == dice2);
+        return new RollData(dice1, dice2, dice1 == dice2);
     }
 
 


### PR DESCRIPTION
Split the dice roll and movement into two methods, as well as another to run both. 


## What changes have I made
Split the dice roll and movement into two methods, one which rolls the dice and returns the values, along with if they are the same, and one which takes in the dice values and moves the counter. I also added a method that rolls the dice and moves the counter, and repeats this if the dice rolls are the same.


## Related Issues / Pull request
Closes #34.

## Proposed Tests
_Propose a few tests to ensure your changes work as expected. It is good to do these tests yourself as well as others._

| Test Description  | Expected result  |
| :---------------- | :--------------- |
| Run PlayTurn() | Counter moves for correct number of spaces, and moves again if double roll. |
| Run MoveCounter() with two integers| Counter moves the amount of spaces of the two integers combined |
| Run RollDice() | Returned boolean should match whether the two integers are the same or not |
